### PR TITLE
downgrade to jdk 8 list

### DIFF
--- a/src/test/java/com/disruptiveinsurance/underwriting/application/PolicyServiceTest.java
+++ b/src/test/java/com/disruptiveinsurance/underwriting/application/PolicyServiceTest.java
@@ -8,7 +8,7 @@ class PolicyServiceTest {
 
     @Test
     public void testConstruction() {
-        var shouldInstantiate = new PolicyService();
+        PolicyService shouldInstantiate = new PolicyService();
     }
 
 }


### PR DESCRIPTION
var was not supported by default circle-ci docker image. 